### PR TITLE
Fix encoding related error

### DIFF
--- a/WpCrack.py
+++ b/WpCrack.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
     target.add_argument("-t", "--target", dest="url", metavar="", help="url of the target", required=True)
     target.add_argument("-u", "--username", dest="usr", metavar="", default="admin", help="username of the target (default: %(default)s)")
     target.add_argument("-p", "--password", dest="pwd", metavar="", help="password of the target (change -p to --p to use a wordlist)")
-    target.add_argument("--p", dest="pwd_list", type=FileType('r'), help=SUPPRESS)
+    target.add_argument("--p", dest="pwd_list", type=FileType('r', encoding="utf-8"), help=SUPPRESS)
     request = parser.add_argument_group()
     request.add_argument("--timeout", metavar="", type=int, default=5, help="timed out for requests (default: %(default)s)")
     request.add_argument("--thread", metavar="", type=int, default=5, help="numbers of threading (default: %(default)s)")


### PR DESCRIPTION
Fix encoding related errors when loading a wordlist comprised of utf-8 characters. Since no encoding is specified by default, Python 3 defaults to cp1254 most cases, which causes this tool to fail with UnicodeDecodeError.